### PR TITLE
Prevent language switch dialog from poping up

### DIFF
--- a/CapLang.ahk
+++ b/CapLang.ahk
@@ -1,1 +1,1 @@
-CapsLock::Send, {Alt Down}{Shift Down}{Shift Up}{Alt Up}
+CapsLock::Send, {Shift Down}{Alt Down}{Alt Up}{Shift Up}


### PR DESCRIPTION
This key sequence prevents Windows 10 & Windows 11 from poping up languages window.

![image](https://user-images.githubusercontent.com/392644/169468381-4b815873-a652-4ef6-bf49-e035eed0f5ac.png)